### PR TITLE
Expand the indicators

### DIFF
--- a/Assets/Scripts/WidgetExpandService.cs
+++ b/Assets/Scripts/WidgetExpandService.cs
@@ -1,5 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
 
@@ -16,6 +18,9 @@ public class WidgetExpandService : MonoBehaviour
     private Type _widgetGeneratorType = null;
     private FieldInfo _widgetCountField = null;
 
+    private Type _indicatorWidgetType = null;
+    private FieldInfo _indicatorLabelsField = null;
+
     private bool _refreshWidgetCount = true;
 
     private void Start()
@@ -25,6 +30,12 @@ public class WidgetExpandService : MonoBehaviour
 
         _widgetCountField = _widgetGeneratorType.GetField("NumberToGenerate", BindingFlags.Instance | BindingFlags.Public);
         Debug.Log("Widget count field = " + _widgetCountField.ToString());
+
+        _indicatorWidgetType = ReflectionHelper.FindType("IndicatorWidget");
+        Debug.Log("Indicator Widget type = " + _indicatorWidgetType.ToString());
+
+        _indicatorLabelsField = _indicatorWidgetType.GetField("Labels", BindingFlags.Public | BindingFlags.Static);
+        Debug.Log("Indicator labels field = " + _indicatorLabelsField.ToString());
 
         KMModSettings modSettingsComponent = GetComponent<KMModSettings>();
         Debug.Log("Widget expand settings = " + modSettingsComponent.Settings);
@@ -48,6 +59,41 @@ public class WidgetExpandService : MonoBehaviour
         _refreshWidgetCount = _refreshWidgetCount || state == KMGameInfo.State.Transitioning || state == KMGameInfo.State.Setup;
     }
 
+    private List<string> MakeList(int count)
+    {
+        List<string> labels = new List<string>
+        {
+            "SND",
+            "CLR",
+            "CAR",
+            "IND",
+            "FRQ",
+            "SIG",
+            "NSA",
+            "MSA",
+            "TRN",
+            "BOB",
+            "FRK",
+            "NLL"
+        };
+        string letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        for (var i = 0; i < count; i++)
+        {
+            
+            string label;
+            do
+            {
+                label = letters[UnityEngine.Random.Range(0, 26)].ToString();
+                label += letters[UnityEngine.Random.Range(0, 26)].ToString();
+                label += letters[UnityEngine.Random.Range(0, 26)].ToString();
+            } while (labels.Contains(label));
+            labels.Add(label);
+        }
+
+        return labels;
+    }
+
     private void UpdateWidgetCount()
     {
         UnityEngine.Object widgetGenerator = FindObjectOfType(_widgetGeneratorType);
@@ -63,6 +109,9 @@ public class WidgetExpandService : MonoBehaviour
         int widgetCount = UnityEngine.Random.Range(Mathf.Min(_modSettings.minimumWidgetCount, _modSettings.maximumWidgetCount), Mathf.Max(_modSettings.minimumWidgetCount, _modSettings.maximumWidgetCount) + 1);
         _widgetCountField.SetValue(widgetGenerator, widgetCount);
         Debug.Log(string.Format("Widget count set to {0}.", widgetCount));
+
+        List<string> list = MakeList((_modSettings.minimumWidgetCount + _modSettings.maximumWidgetCount + 1) / 2);
+        _indicatorLabelsField.SetValue(null, list);
 
         _refreshWidgetCount = false;
     }

--- a/Assets/Scripts/WidgetExpandService.cs
+++ b/Assets/Scripts/WidgetExpandService.cs
@@ -2,15 +2,19 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using UnityEngine;
 
 public class WidgetExpandService : MonoBehaviour
 {
+    private static int SettingsVersion = 1;
     public class WidgetExpandModSettings
     {
+        public int fileVersion;
         public int minimumWidgetCount = 7;
         public int maximumWidgetCount = 7;
+        public bool enableCustomIndicators = true;
     }
 
     private WidgetExpandModSettings _modSettings = new WidgetExpandModSettings();
@@ -21,6 +25,8 @@ public class WidgetExpandService : MonoBehaviour
     private Type _indicatorWidgetType = null;
     private FieldInfo _indicatorLabelsField = null;
 
+    private List<string> _knownIndicators = null;
+    private List<string> _customIndicators = null;
     private bool _refreshWidgetCount = true;
 
     private void Start()
@@ -37,10 +43,22 @@ public class WidgetExpandService : MonoBehaviour
         _indicatorLabelsField = _indicatorWidgetType.GetField("Labels", BindingFlags.Public | BindingFlags.Static);
         Debug.Log("Indicator labels field = " + _indicatorLabelsField.ToString());
 
+        _knownIndicators = (List<string>) _indicatorLabelsField.GetValue(null);
+        string indicators = "";
+        foreach (string label in _knownIndicators)
+        {
+            if (indicators == "")
+                indicators = label;
+            else
+                indicators += ", " + label;
+        }
+        Debug.LogFormat("The Following Indicators are present: {0}", indicators);
+
         KMModSettings modSettingsComponent = GetComponent<KMModSettings>();
         Debug.Log("Widget expand settings = " + modSettingsComponent.Settings);
         _modSettings = JsonConvert.DeserializeObject<WidgetExpandModSettings>(modSettingsComponent.Settings);
         Debug.Log(string.Format("Widget expand settings: minimum = {0}, maximum = {1}", _modSettings.minimumWidgetCount, _modSettings.maximumWidgetCount));
+        Debug.Log(string.Format("Enable custom indicators: {0}", _modSettings.enableCustomIndicators));
 
         KMGameInfo gameInfoComponent = GetComponent<KMGameInfo>();
         gameInfoComponent.OnStateChange += OnStateChange;
@@ -59,37 +77,87 @@ public class WidgetExpandService : MonoBehaviour
         _refreshWidgetCount = _refreshWidgetCount || state == KMGameInfo.State.Transitioning || state == KMGameInfo.State.Setup;
     }
 
-    private List<string> MakeList(int count)
+    private void RefreshSettings()
     {
-        List<string> labels = new List<string>
+        string ModSettings = Path.Combine(Path.Combine(Application.persistentDataPath, "Modsettings"), "WidgetExpand-settings.txt");
+        if (File.Exists(ModSettings))
         {
-            "SND",
-            "CLR",
-            "CAR",
-            "IND",
-            "FRQ",
-            "SIG",
-            "NSA",
-            "MSA",
-            "TRN",
-            "BOB",
-            "FRK",
-            "NLL"
-        };
-        string letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+            Debug.Log("Attempting to Refresh the settings");
+            string settings = File.ReadAllText(ModSettings);
+            _modSettings = JsonConvert.DeserializeObject<WidgetExpandModSettings>(settings);
 
+            if (_modSettings.fileVersion != SettingsVersion)
+            {
+                Debug.Log("Settings Version changed - Adding new Settings");
+                _modSettings.fileVersion = SettingsVersion;
+                settings = JsonConvert.SerializeObject(_modSettings, Formatting.Indented);
+                File.WriteAllText(ModSettings, settings);
+                Debug.LogFormat("New settings = {0}", settings);
+            }
+        }
+    }
+
+    private void Shuffle()
+    {
+        if (_customIndicators == null)
+        {
+            string _letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+            _customIndicators = new List<string>();
+
+            foreach (var x in _letters)
+                foreach (var y in _letters)
+                    foreach (var z in _letters)
+                        _customIndicators.Add(x.ToString() + y + z);
+
+            foreach (var x in _knownIndicators)
+                _customIndicators.Remove(x);
+            _customIndicators.Remove("NLL");
+        }
+
+        var list = _customIndicators;
+        int n = _customIndicators.Count;
+        while (n-- > 0)
+        {
+            int k = UnityEngine.Random.Range(0, n+1);
+            string value = list[k];
+            list[k] = list[n];
+            list[n] = value;
+        }
+    }
+
+    private List<string> MakeList()
+    {
+        Shuffle();
+
+        int count = Math.Max(_modSettings.maximumWidgetCount - 12, (_modSettings.minimumWidgetCount + 1) / 2);
+        count = Math.Min(count, _customIndicators.Count);
+
+        List<string> labels = new List<string>(_knownIndicators);
+        if (!_modSettings.enableCustomIndicators)
+            return labels;
+
+        labels.Add("NLL");
+
+
+        Debug.Log("In Addition to the standard 11 Indicators as well as NLL");
+        Debug.LogFormat("The following {0} may spawn on the upcoming bomb(s)",count);
+
+        
+        string indicators = "";
         for (var i = 0; i < count; i++)
         {
-            
-            string label;
-            do
+            if (indicators == "")
+                indicators = _customIndicators[i];
+            else
+                indicators += ", " + _customIndicators[i];
+            if ((i % 16) == 15)
             {
-                label = letters[UnityEngine.Random.Range(0, 26)].ToString();
-                label += letters[UnityEngine.Random.Range(0, 26)].ToString();
-                label += letters[UnityEngine.Random.Range(0, 26)].ToString();
-            } while (labels.Contains(label));
-            labels.Add(label);
+                Debug.Log(indicators);
+                indicators = "";
+            }
+            labels.Add(_customIndicators[i]);
         }
+        Debug.Log(indicators);
 
         return labels;
     }
@@ -103,6 +171,9 @@ public class WidgetExpandService : MonoBehaviour
             return;
         }
 
+        //Get Fresh settings to apply to the next bomb
+        RefreshSettings();
+
         //Because the rule manager resets the random seed to 1 before bomb generation
         UnityEngine.Random.InitState((int)Time.time);
 
@@ -110,9 +181,9 @@ public class WidgetExpandService : MonoBehaviour
         _widgetCountField.SetValue(widgetGenerator, widgetCount);
         Debug.Log(string.Format("Widget count set to {0}.", widgetCount));
 
-        List<string> list = MakeList((_modSettings.minimumWidgetCount + _modSettings.maximumWidgetCount + 1) / 2);
+        List<string> list = MakeList();
         _indicatorLabelsField.SetValue(null, list);
-
+        
         _refreshWidgetCount = false;
     }
 }

--- a/Assets/Scripts/WidgetExpandService.cs
+++ b/Assets/Scripts/WidgetExpandService.cs
@@ -17,7 +17,7 @@ public class WidgetExpandService : MonoBehaviour
         public int minimumWidgetCount = 7;
         public int maximumWidgetCount = 7;
         public bool allowSerialNumberChange = true;
-        public int minimumCustomIndicators = 5;
+        public int minimumCustomIndicators = 1;
         public bool allowCustomIndicators = true;
     }
 
@@ -42,8 +42,12 @@ public class WidgetExpandService : MonoBehaviour
         Debug.LogFormat("[WidgetExpander] " + text, formatting);
     }
 
+    private KMModSettings moduleSettings;
+
     private void ReadSettings()
     {
+        DebugLog("Settings as read by KMModSettings:\n{0}\n", GetComponent<KMModSettings>().Settings);
+        DebugLog("Settings as read by moduleSettings initialized at start():\n{0}\n",moduleSettings.Settings);
         string ModSettingsDirectory = Path.Combine(Application.persistentDataPath, "Modsettings");
         string ModSettings = Path.Combine(ModSettingsDirectory, "WidgetExpand-settings.txt");
         if (File.Exists(ModSettings))
@@ -118,6 +122,7 @@ public class WidgetExpandService : MonoBehaviour
 
         KMGameInfo gameInfoComponent = GetComponent<KMGameInfo>();
         gameInfoComponent.OnStateChange += OnStateChange;
+        moduleSettings = GetComponent<KMModSettings>();
     }
 
     private void LateUpdate()

--- a/Assets/modSettings.json
+++ b/Assets/modSettings.json
@@ -1,11 +1,9 @@
 {
-        "fileVersion": 2,
-
-        "allowWidgetCountChange": true,
-        "minimumWidgetCount": 7,
-        "maximumWidgetCount": 7,
-
-        "enableCustomIndicators": true,
-
-        "allowSerialNumberChange": true
+  "fileVersion": 2,
+  "allowWidgetCountChange": true,
+  "minimumWidgetCount": 7,
+  "maximumWidgetCount": 7,
+  "allowSerialNumberChange": true,
+  "minimumCustomIndicators": 5,
+  "allowCustomIndicators": true
 }

--- a/Assets/modSettings.json
+++ b/Assets/modSettings.json
@@ -4,6 +4,6 @@
   "minimumWidgetCount": 7,
   "maximumWidgetCount": 7,
   "allowSerialNumberChange": true,
-  "minimumCustomIndicators": 5,
+  "minimumCustomIndicators": 1,
   "allowCustomIndicators": true
 }

--- a/Assets/modSettings.json
+++ b/Assets/modSettings.json
@@ -1,4 +1,6 @@
 {
+	"fileVersion": 1,
 	"minimumWidgetCount": 7,
-	"maximumWidgetCount": 7
+	"maximumWidgetCount": 7,
+        "enableCustomIndicators": true
 }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -29,7 +29,6 @@ PlayerSettings:
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
-  tizenShowActivityIndicatorOnLoading: -1
   iosAppInBackgroundBehavior: 0
   displayResolutionDialog: 1
   iosAllowHTTPDownload: 1
@@ -45,7 +44,6 @@ PlayerSettings:
   runInBackground: 0
   captureSingleScreen: 0
   Override IPod Music: 0
-  muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
   submitAnalytics: 1
   usePlayerLog: 1
@@ -125,7 +123,6 @@ PlayerSettings:
   iPhoneTargetOSVersion: 22
   tvOSSdkVersion: 0
   tvOSTargetOSVersion: 900
-  tvOSRequireExtendedGameController: 0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
@@ -146,7 +143,6 @@ PlayerSettings:
   tvOSSmallIconLayers: []
   tvOSLargeIconLayers: []
   tvOSTopShelfImageLayers: []
-  tvOSTopShelfImageWideLayers: []
   iOSLaunchScreenType: 0
   iOSLaunchScreenPortrait: {fileID: 0}
   iOSLaunchScreenLandscape: {fileID: 0}
@@ -166,7 +162,6 @@ PlayerSettings:
   iOSLaunchScreeniPadCustomXibPath: 
   iOSDeviceRequirements: []
   iOSURLSchemes: []
-  appleDeveloperTeamID: 
   AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -217,15 +212,12 @@ PlayerSettings:
   wiiUSystemHeapSize: 128
   wiiUTVStartupScreen: {fileID: 0}
   wiiUGamePadStartupScreen: {fileID: 0}
-  wiiUDrcBufferDisabled: 0
   wiiUProfilerLibPath: 
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
   enableCrashReportAPI: 0
-  cameraUsageDescription: 
   locationUsageDescription: 
-  microphoneUsageDescription: 
   XboxTitleId: 
   XboxImageXexPath: 
   XboxSpaPath: 
@@ -265,8 +257,7 @@ PlayerSettings:
   ps4AppType: 0
   ps4ParamSfxPath: 
   ps4VideoOutPixelFormat: 0
-  ps4VideoOutInitialWidth: 1920
-  ps4VideoOutReprojectionRate: 120
+  ps4VideoOutResolution: 4
   ps4PronunciationXMLPath: 
   ps4PronunciationSIGPath: 
   ps4BackgroundImagePath: 
@@ -295,12 +286,9 @@ PlayerSettings:
   ps4pnFriends: 1
   ps4pnGameCustomData: 1
   playerPrefsSupport: 0
-  ps4UseResolutionFallback: 0
-  restrictedAudioUsageRights: 0
   ps4ReprojectionSupport: 0
   ps4UseAudio3dBackend: 0
   ps4SocialScreenEnabled: 0
-  ps4ScriptOptimizationLevel: 3
   ps4Audio3dVirtualSpeakerCount: 14
   ps4attribCpuUsage: 0
   ps4PatchPkgPath: 


### PR DESCRIPTION
This should expand the indicators large enough, to avoid having the
possibility of multiple NLL indicators appearing on the bomb.